### PR TITLE
fix for webOS 3.0

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,31 @@
+name: package
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: apt-get install
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: sudo apt-get update && sudo apt-get dist-upgrade -y && sudo apt-get install -y npm
+    - name: npm install
+      run: npm install
+    - name: npm build
+      run: npm run build
+    - name: npm package
+      run: npm run package
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: '*.ipk'
+        retention-days: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: apt-get install
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: sudo apt-get update && sudo apt-get install -y npm
+    - name: npm install
+      run: npm install
+    - name: npm build
+      run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "org.webosbrew.autostart",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "org.webosbrew.autostart",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "core-js": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.webosbrew.autostart",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Autostart test application",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Under webOS 3.0, there were 2 issues:

- The call to addDevice didn't work, because mandatory parameters are missing (I suspect they are optional under other versions of webOS)

- The call to addDevice only worked once, and failed afterwards because the app is already registered, and the code considered it a fatal error, so didn't go through and stopped before actually launching the hbchannel autostart service. Maybe under different versions of webOS, adding a pre-existing app through addDevice is considered a no-op by luna service and doesn't return an error, but under webOS 3.0 at least, this fails. Modify the code to recognize this exact error and consider it a success.

Added some comments and more logs to help debugging potential future cases.